### PR TITLE
Exception Users Variable

### DIFF
--- a/vsphere/6.7/vsphere/inspec/vmware-esxi-6.7-stig-baseline/controls/ESXI-67-000003.rb
+++ b/vsphere/6.7/vsphere/inspec/vmware-esxi-6.7-stig-baseline/controls/ESXI-67-000003.rb
@@ -41,7 +41,7 @@ unnecessary users from the exceptions list."
 
   command = "$vmhost = Get-VMHost -Name #{input('vmhostName')} | Get-View; (Get-View $vmhost.ConfigManager.HostAccessManager).QueryLockdownExceptions()"
   describe powercli_command(command) do
-    its('stdout.strip') { should cmp "" }
+    its('stdout.strip') { should cmp "#{input('exceptionUsers')}" }
   end
 
 end

--- a/vsphere/6.7/vsphere/inspec/vmware-esxi-6.7-stig-baseline/inspec.yml
+++ b/vsphere/6.7/vsphere/inspec/vmware-esxi-6.7-stig-baseline/inspec.yml
@@ -36,3 +36,7 @@ inputs:
     value: "15160138"
     type: string
     description: "ESXi Patch Build Number to check for latest updates.  Refer to https://kb.vmware.com/s/article/2143832 for build numbers"
+  - name: exceptionUsers
+    value: ""
+    type: string
+    description: "Users allowed to bypass lockdown mode."


### PR DESCRIPTION
Our environment requires a Lockdown mode user exception for ACAS scanning, so, I modified the ESXI control ESXI-67-000003 to use a variable called exceptionUsers, then added the variable to the end of the inspec.yml.