### PR TITLE
Remove the need for the photonIP variable

### DIFF
--- a/vsphere/6.7/vcsa/inspec/vmware-vcsa-6.7-stig-baseline/photon/controls/PHTN-10-000055.rb
+++ b/vsphere/6.7/vcsa/inspec/vmware-vcsa-6.7-stig-baseline/photon/controls/PHTN-10-000055.rb
@@ -31,8 +31,9 @@ At the command line, execute the following command:
 
 # service sshd reload"
 
-  describe command('sshd -T|&grep -i ListenAddress') do
-    its ('stdout.strip') { should match /listenaddress #{input('photonIp')}/ }
+  photonIp = command("ip -br addr show eth0 |&awk '{print $3}' |&cut -d'/' -f1").stdout.strip
+  describe command("sshd -T|&grep -i ListenAddress|&awk '{print $2}' |&cut -d':' -f1") do
+    its ('stdout.strip') { should match /#{photonIp}/ }
   end
 
 end

--- a/vsphere/6.7/vcsa/inspec/vmware-vcsa-6.7-stig-baseline/photon/inspec.yml
+++ b/vsphere/6.7/vcsa/inspec/vmware-vcsa-6.7-stig-baseline/photon/inspec.yml
@@ -8,9 +8,6 @@ summary: An InSpec Compliance Profile
 version: 6.7.0
 
 inputs:
-- name: photonIp
-  type: string
-  value: "x.x.x.x"  #Enter IP for PhotonOS
 - name: ntpServer1
   type: string
   value: "x.x.x.x"  #Enter IP or FQDN of NTP Server


### PR DESCRIPTION
Removed requirement for Photon IP variable by grabbing IP address from eth0 interface.