### PR TITLE
VMware.PowerCli -> VMware.VimAutomation.Core

### DIFF
--- a/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_Compliance_Report.ps1
+++ b/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_Compliance_Report.ps1
@@ -246,7 +246,7 @@ $V94781 = $true  #log level
 
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI","ReportHTML")
+$modules = @("VMware.VimAutomation.Core","ReportHTML")
 
 #Check for correct modules
 Function checkModule ($m){

--- a/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_ESXi_Inspec_Runner.ps1
+++ b/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_ESXi_Inspec_Runner.ps1
@@ -39,7 +39,7 @@ param (
 $date = Get-Date
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
 Function checkModule ($m){

--- a/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_ESXi_Remediation.ps1
+++ b/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_ESXi_Remediation.ps1
@@ -182,7 +182,7 @@ Function Write-ToConsoleGreen ($Details){
 }
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Function to check for correct modules
 Function checkModule ($m){

--- a/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_VM_Inspec_Runner.ps1
+++ b/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_VM_Inspec_Runner.ps1
@@ -39,7 +39,7 @@ param (
 $date = Get-Date
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
 Function checkModule ($m){

--- a/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_VM_Remediation.ps1
+++ b/vsphere/6.7/vsphere/powercli/VMware_vSphere_6.7_STIG_VM_Remediation.ps1
@@ -75,7 +75,7 @@ $vmconfig = @{
 }
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
 Function checkModule ($m){

--- a/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_Inspec_Runner.ps1
+++ b/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_Inspec_Runner.ps1
@@ -39,7 +39,7 @@ param (
 $date = Get-Date
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
 Function checkModule ($m){

--- a/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_Remediation.ps1
+++ b/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_Remediation.ps1
@@ -185,7 +185,7 @@ Function Write-ToConsoleGreen ($Details){
 }
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Function to check for correct modules
 Function checkModule ($m){

--- a/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_Inspec_Runner.ps1
+++ b/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_Inspec_Runner.ps1
@@ -39,7 +39,7 @@ param (
 $date = Get-Date
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
 Function checkModule ($m){

--- a/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_Remediation.ps1
+++ b/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_Remediation.ps1
@@ -37,74 +37,70 @@
 #>
 [CmdletBinding()]
 param (
-    [Parameter(Mandatory=$true,
-    HelpMessage="Enter the vCenter/ESXi FQDN or IP to connect to")]
+    [Parameter(Mandatory = $true,
+        HelpMessage = "Enter the vCenter/ESXi FQDN or IP to connect to")]
     [ValidateNotNullOrEmpty()]
     [string]$vcenter,
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$virtualmachine,
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$cluster,
-    [Parameter(Mandatory=$false,
-    HelpMessage="Use -all option to remediate all VMs in target vCenter/ESXi")]
+    [Parameter(Mandatory = $false,
+        HelpMessage = "Use -all option to remediate all VMs in target vCenter/ESXi")]
     [ValidateNotNullOrEmpty()]
-    [switch]$all=$false
+    [switch]$all = $false
 )
 
 $vmconfig = @{
     #Hardening/STIG Settings
-    vmAdvSettings = @{
-        "isolation.tools.copy.disable" = $true
-        "isolation.tools.dnd.disable" = $true
-        "isolation.tools.paste.disable" = $true
-        "isolation.tools.diskShrink.disable" = $true
-        "isolation.tools.diskWiper.disable" = $true
+    vmAdvSettings       = @{
+        "isolation.tools.copy.disable"          = $true
+        "isolation.tools.dnd.disable"           = $true
+        "isolation.tools.paste.disable"         = $true
+        "isolation.tools.diskShrink.disable"    = $true
+        "isolation.tools.diskWiper.disable"     = $true
         "isolation.tools.hgfsServerSet.disable" = $true
-        "RemoteDisplay.maxConnections" = "1"
-        "RemoteDisplay.vnc.enabled" = $false
-        "tools.setinfo.sizeLimit" = "1048576"
-        "isolation.device.connectable.disable" = $true
-        "tools.guestlib.enableHostInfo" = $false
-        "tools.guest.desktop.autolock" = $true
-        "mks.enable3d" = $false
-        "log.rotateSize" = "2048000"
-        "log.keepOld" = "10"
+        "RemoteDisplay.maxConnections"          = "1"
+        "RemoteDisplay.vnc.enabled"             = $false
+        "tools.setinfo.sizeLimit"               = "1048576"
+        "isolation.device.connectable.disable"  = $true
+        "tools.guestlib.enableHostInfo"         = $false
+        "tools.guest.desktop.autolock"          = $true
+        "mks.enable3d"                          = $false
+        "log.rotateSize"                        = "2048000"
+        "log.keepOld"                           = "10"
     }
     vmAdvSettingsRemove = ("sched.mem.pshare.salt")
-    vmotionEncryption = "opportunistic" #disabled, required, opportunistic
-    vmLogging = $true
+    vmotionEncryption   = "opportunistic" #disabled, required, opportunistic
+    vmLogging           = $true
 }
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI")
+$modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
-Function checkModule ($m){
-    if (Get-Module | Where-Object {$_.Name -eq $m}) {
+Function checkModule ($m) {
+    if (Get-Module | Where-Object { $_.Name -eq $m }) {
         Write-Host "Module $m is already imported."
-    }
-    else{
+    } else {
         Write-Host "Trying to import module $m"
         Import-Module $m -Verbose
     }
 }
 
-Function Write-ToConsole ($Details){
-	$LogDate = Get-Date -Format T
-	Write-Host "$($LogDate) $Details"
+Function Write-ToConsole ($Details) {
+    $LogDate = Get-Date -Format T
+    Write-Host "$($LogDate) $Details"
 }  
 
 #Load Modules
-Try
-{
-    ForEach($module in $modules){
+Try {
+    ForEach ($module in $modules) {
         checkModule $module
     }
-}
-Catch
-{
+} Catch {
     Write-Error "Failed to load modules"
     Write-Error $_.Exception
     Exit
@@ -115,35 +111,31 @@ Write-ToConsole "...Enter credentials to connect to vCenter"
 $vccred = Get-Credential -Message "Enter credentials for vCenter"
 
 #Connect to vCenter Server
-Try
-{
+Try {
     Write-ToConsole "...Connecting to vCenter Server $vcenter"
     Connect-VIServer -Server $vcenter -Credential $vccred -Protocol https -ErrorAction Stop | Out-Null
-}
-Catch
-{
+} Catch {
     Write-Error "Failed to connect to $vcenter"
     Write-Error $_.Exception
     Exit
 }
 
 #Get host objects
-Try{
-    If($all){
+Try {
+    If ($all) {
         Write-ToConsole "...Getting PowerCLI objects for all virtual machines hosts in vCenter: $vcenter"
         $vms = Get-VM | Sort-Object Name
-    }elseif($cluster) {
+    } elseif ($cluster) {
         Write-ToConsole "...Getting PowerCLI objects for all virtual machines in cluster: $cluster"
         $vms = Get-Cluster -Name $cluster | Get-VM | Sort-Object Name
-    }elseif($virtualmachine){
+    } elseif ($virtualmachine) {
         Write-ToConsole "...Getting PowerCLI object for virtual machine: $virtualmachine"
         $vms = Get-VM -Name $virtualmachine | Sort-Object Name
-    }else{
+    } else {
         Write-ToConsole "...No remediation options specified exiting script"
         Exit
     }
-}
-Catch{
+} Catch {
     Write-Error "...Failed to get PowerCLI objects"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -151,28 +143,28 @@ Catch{
 }
 
 ## Remediate Virtual Machine advanced settings
-Try{
-    ForEach($vm in $vms){
+Try {
+    ForEach ($vm in $vms) {
         Write-ToConsole "...Remediating advanced settings on $vm on $vcenter"
-            ForEach($setting in ($vmconfig.vmAdvSettings.GetEnumerator() | Sort-Object Name)){
+        ForEach ($setting in ($vmconfig.vmAdvSettings.GetEnumerator() | Sort-Object Name)) {
             #Pulling values for each setting specified
             $name = $setting.name
             $value = $setting.value
-                #Checking to see if current setting exists
-                If($asetting = $vm | Get-AdvancedSetting -Name $name){
-                    If($asetting.value -eq $value){
+            #Checking to see if current setting exists
+            If ($asetting = $vm | Get-AdvancedSetting -Name $name) {
+                If ($asetting.value -eq $value) {
                     Write-ToConsole "...Setting $name is already configured correctly to $value on $vm"
-                    }else{
-                        Write-ToConsole "...Setting $name was incorrectly set to $($asetting.value) on $vm setting to $value"
-                        $asetting | Set-AdvancedSetting -Value $value -Confirm:$false
-                    }
-                }else{
-                    Write-ToConsole "...Setting $name does not exist on $vm creating setting..."
-                    $vm | New-AdvancedSetting -Name $name -Value $value -Confirm:$false
+                } else {
+                    Write-ToConsole "...Setting $name was incorrectly set to $($asetting.value) on $vm setting to $value"
+                    $asetting | Set-AdvancedSetting -Value $value -Confirm:$false
                 }
+            } else {
+                Write-ToConsole "...Setting $name does not exist on $vm creating setting..."
+                $vm | New-AdvancedSetting -Name $name -Value $value -Confirm:$false
             }
+        }
     }
-}Catch{
+} Catch {
     Write-Error "...Failed to get set virtual machine advanced settings"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -180,21 +172,20 @@ Try{
 }
 
 ## Remove advanced settings
-Try{
-    ForEach($vm in $vms){
+Try {
+    ForEach ($vm in $vms) {
         Write-ToConsole "...Removing advanced settings if necessary on $vm on $vcenter"
-            ForEach($setting in ($vmconfig.vmAdvSettingsRemove | Sort-Object Name)){
-                #Checking to see if current setting exists
-                If($asetting = $vm | Get-AdvancedSetting -Name $setting){
-                    Write-ToConsole "...Setting $setting exists on $vm...removing setting"
-                    $asetting | Remove-AdvancedSetting -Confirm:$false
-                }
-                else{
-                    Write-ToConsole "...Setting $setting does not exist on $vm"
-                }
-            }   
+        ForEach ($setting in ($vmconfig.vmAdvSettingsRemove | Sort-Object Name)) {
+            #Checking to see if current setting exists
+            If ($asetting = $vm | Get-AdvancedSetting -Name $setting) {
+                Write-ToConsole "...Setting $setting exists on $vm...removing setting"
+                $asetting | Remove-AdvancedSetting -Confirm:$false
+            } else {
+                Write-ToConsole "...Setting $setting does not exist on $vm"
+            }
+        }   
     }
-}Catch{
+} Catch {
     Write-Error "...Failed to remove virtual machine advanced settings"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -202,11 +193,11 @@ Try{
 }
 
 ## Set virtual machine vMotion Encryption
-Try{
-    ForEach($vm in $vms){
-        If($vm.extensiondata.Config.MigrateEncryption -eq $vmconfig.vmotionEncryption){
+Try {
+    ForEach ($vm in $vms) {
+        If ($vm.extensiondata.Config.MigrateEncryption -eq $vmconfig.vmotionEncryption) {
             Write-ToConsole "...vMotion encryption set correctly on $vm to $($vmconfig.vmotionEncryption)"
-        }else{
+        } else {
             Write-ToConsole "...vMotion encryption was incorrectly set to $($vm.extensiondata.Config.MigrateEncryption) on $vm"
             $vmv = $vm | get-view
             $config = new-object VMware.Vim.VirtualMachineConfigSpec
@@ -215,7 +206,7 @@ Try{
             $vmv.ReconfigVM($config)
         }
     }
-}Catch{
+} Catch {
     Write-Error "...Failed to configure virtual machine vMotion encryption"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -223,11 +214,11 @@ Try{
 }
 
 ## Set virtual machine logging
-Try{
-    ForEach($vm in $vms){
-        If($vm.ExtensionData.Config.Flags.EnableLogging -eq $vmconfig.vmLogging){
+Try {
+    ForEach ($vm in $vms) {
+        If ($vm.ExtensionData.Config.Flags.EnableLogging -eq $vmconfig.vmLogging) {
             Write-ToConsole "...Logging set correctly on $vm to $($vmconfig.vmLogging)"
-        }else{
+        } else {
             Write-ToConsole "...Logging was incorrectly set to $($vm.ExtensionData.Config.Flags.EnableLogging) on $vm"
             $vmv = $vm | get-view
             $config = new-object VMware.Vim.VirtualMachineConfigSpec
@@ -236,7 +227,7 @@ Try{
             $vmv.ReconfigVM($config)
         }
     }
-}Catch{
+} Catch {
     Write-Error "...Failed to configure virtual machine logging"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false

--- a/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_Remediation.ps1
+++ b/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_Remediation.ps1
@@ -37,70 +37,74 @@
 #>
 [CmdletBinding()]
 param (
-    [Parameter(Mandatory = $true,
-        HelpMessage = "Enter the vCenter/ESXi FQDN or IP to connect to")]
+    [Parameter(Mandatory=$true,
+    HelpMessage="Enter the vCenter/ESXi FQDN or IP to connect to")]
     [ValidateNotNullOrEmpty()]
     [string]$vcenter,
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
     [string]$virtualmachine,
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory=$false)]
     [ValidateNotNullOrEmpty()]
     [string]$cluster,
-    [Parameter(Mandatory = $false,
-        HelpMessage = "Use -all option to remediate all VMs in target vCenter/ESXi")]
+    [Parameter(Mandatory=$false,
+    HelpMessage="Use -all option to remediate all VMs in target vCenter/ESXi")]
     [ValidateNotNullOrEmpty()]
-    [switch]$all = $false
+    [switch]$all=$false
 )
 
 $vmconfig = @{
     #Hardening/STIG Settings
-    vmAdvSettings       = @{
-        "isolation.tools.copy.disable"          = $true
-        "isolation.tools.dnd.disable"           = $true
-        "isolation.tools.paste.disable"         = $true
-        "isolation.tools.diskShrink.disable"    = $true
-        "isolation.tools.diskWiper.disable"     = $true
+    vmAdvSettings = @{
+        "isolation.tools.copy.disable" = $true
+        "isolation.tools.dnd.disable" = $true
+        "isolation.tools.paste.disable" = $true
+        "isolation.tools.diskShrink.disable" = $true
+        "isolation.tools.diskWiper.disable" = $true
         "isolation.tools.hgfsServerSet.disable" = $true
-        "RemoteDisplay.maxConnections"          = "1"
-        "RemoteDisplay.vnc.enabled"             = $false
-        "tools.setinfo.sizeLimit"               = "1048576"
-        "isolation.device.connectable.disable"  = $true
-        "tools.guestlib.enableHostInfo"         = $false
-        "tools.guest.desktop.autolock"          = $true
-        "mks.enable3d"                          = $false
-        "log.rotateSize"                        = "2048000"
-        "log.keepOld"                           = "10"
+        "RemoteDisplay.maxConnections" = "1"
+        "RemoteDisplay.vnc.enabled" = $false
+        "tools.setinfo.sizeLimit" = "1048576"
+        "isolation.device.connectable.disable" = $true
+        "tools.guestlib.enableHostInfo" = $false
+        "tools.guest.desktop.autolock" = $true
+        "mks.enable3d" = $false
+        "log.rotateSize" = "2048000"
+        "log.keepOld" = "10"
     }
     vmAdvSettingsRemove = ("sched.mem.pshare.salt")
-    vmotionEncryption   = "opportunistic" #disabled, required, opportunistic
-    vmLogging           = $true
+    vmotionEncryption = "opportunistic" #disabled, required, opportunistic
+    vmLogging = $true
 }
 
 #Modules needed to run script and load
 $modules = @("VMware.VimAutomation.Core")
 
 #Check for correct modules
-Function checkModule ($m) {
-    if (Get-Module | Where-Object { $_.Name -eq $m }) {
+Function checkModule ($m){
+    if (Get-Module | Where-Object {$_.Name -eq $m}) {
         Write-Host "Module $m is already imported."
-    } else {
+    }
+    else{
         Write-Host "Trying to import module $m"
         Import-Module $m -Verbose
     }
 }
 
-Function Write-ToConsole ($Details) {
-    $LogDate = Get-Date -Format T
-    Write-Host "$($LogDate) $Details"
+Function Write-ToConsole ($Details){
+	$LogDate = Get-Date -Format T
+	Write-Host "$($LogDate) $Details"
 }  
 
 #Load Modules
-Try {
-    ForEach ($module in $modules) {
+Try
+{
+    ForEach($module in $modules){
         checkModule $module
     }
-} Catch {
+}
+Catch
+{
     Write-Error "Failed to load modules"
     Write-Error $_.Exception
     Exit
@@ -111,31 +115,35 @@ Write-ToConsole "...Enter credentials to connect to vCenter"
 $vccred = Get-Credential -Message "Enter credentials for vCenter"
 
 #Connect to vCenter Server
-Try {
+Try
+{
     Write-ToConsole "...Connecting to vCenter Server $vcenter"
     Connect-VIServer -Server $vcenter -Credential $vccred -Protocol https -ErrorAction Stop | Out-Null
-} Catch {
+}
+Catch
+{
     Write-Error "Failed to connect to $vcenter"
     Write-Error $_.Exception
     Exit
 }
 
 #Get host objects
-Try {
-    If ($all) {
+Try{
+    If($all){
         Write-ToConsole "...Getting PowerCLI objects for all virtual machines hosts in vCenter: $vcenter"
         $vms = Get-VM | Sort-Object Name
-    } elseif ($cluster) {
+    }elseif($cluster) {
         Write-ToConsole "...Getting PowerCLI objects for all virtual machines in cluster: $cluster"
         $vms = Get-Cluster -Name $cluster | Get-VM | Sort-Object Name
-    } elseif ($virtualmachine) {
+    }elseif($virtualmachine){
         Write-ToConsole "...Getting PowerCLI object for virtual machine: $virtualmachine"
         $vms = Get-VM -Name $virtualmachine | Sort-Object Name
-    } else {
+    }else{
         Write-ToConsole "...No remediation options specified exiting script"
         Exit
     }
-} Catch {
+}
+Catch{
     Write-Error "...Failed to get PowerCLI objects"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -143,28 +151,28 @@ Try {
 }
 
 ## Remediate Virtual Machine advanced settings
-Try {
-    ForEach ($vm in $vms) {
+Try{
+    ForEach($vm in $vms){
         Write-ToConsole "...Remediating advanced settings on $vm on $vcenter"
-        ForEach ($setting in ($vmconfig.vmAdvSettings.GetEnumerator() | Sort-Object Name)) {
+            ForEach($setting in ($vmconfig.vmAdvSettings.GetEnumerator() | Sort-Object Name)){
             #Pulling values for each setting specified
             $name = $setting.name
             $value = $setting.value
-            #Checking to see if current setting exists
-            If ($asetting = $vm | Get-AdvancedSetting -Name $name) {
-                If ($asetting.value -eq $value) {
+                #Checking to see if current setting exists
+                If($asetting = $vm | Get-AdvancedSetting -Name $name){
+                    If($asetting.value -eq $value){
                     Write-ToConsole "...Setting $name is already configured correctly to $value on $vm"
-                } else {
-                    Write-ToConsole "...Setting $name was incorrectly set to $($asetting.value) on $vm setting to $value"
-                    $asetting | Set-AdvancedSetting -Value $value -Confirm:$false
+                    }else{
+                        Write-ToConsole "...Setting $name was incorrectly set to $($asetting.value) on $vm setting to $value"
+                        $asetting | Set-AdvancedSetting -Value $value -Confirm:$false
+                    }
+                }else{
+                    Write-ToConsole "...Setting $name does not exist on $vm creating setting..."
+                    $vm | New-AdvancedSetting -Name $name -Value $value -Confirm:$false
                 }
-            } else {
-                Write-ToConsole "...Setting $name does not exist on $vm creating setting..."
-                $vm | New-AdvancedSetting -Name $name -Value $value -Confirm:$false
             }
-        }
     }
-} Catch {
+}Catch{
     Write-Error "...Failed to get set virtual machine advanced settings"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -172,20 +180,21 @@ Try {
 }
 
 ## Remove advanced settings
-Try {
-    ForEach ($vm in $vms) {
+Try{
+    ForEach($vm in $vms){
         Write-ToConsole "...Removing advanced settings if necessary on $vm on $vcenter"
-        ForEach ($setting in ($vmconfig.vmAdvSettingsRemove | Sort-Object Name)) {
-            #Checking to see if current setting exists
-            If ($asetting = $vm | Get-AdvancedSetting -Name $setting) {
-                Write-ToConsole "...Setting $setting exists on $vm...removing setting"
-                $asetting | Remove-AdvancedSetting -Confirm:$false
-            } else {
-                Write-ToConsole "...Setting $setting does not exist on $vm"
-            }
-        }   
+            ForEach($setting in ($vmconfig.vmAdvSettingsRemove | Sort-Object Name)){
+                #Checking to see if current setting exists
+                If($asetting = $vm | Get-AdvancedSetting -Name $setting){
+                    Write-ToConsole "...Setting $setting exists on $vm...removing setting"
+                    $asetting | Remove-AdvancedSetting -Confirm:$false
+                }
+                else{
+                    Write-ToConsole "...Setting $setting does not exist on $vm"
+                }
+            }   
     }
-} Catch {
+}Catch{
     Write-Error "...Failed to remove virtual machine advanced settings"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -193,11 +202,11 @@ Try {
 }
 
 ## Set virtual machine vMotion Encryption
-Try {
-    ForEach ($vm in $vms) {
-        If ($vm.extensiondata.Config.MigrateEncryption -eq $vmconfig.vmotionEncryption) {
+Try{
+    ForEach($vm in $vms){
+        If($vm.extensiondata.Config.MigrateEncryption -eq $vmconfig.vmotionEncryption){
             Write-ToConsole "...vMotion encryption set correctly on $vm to $($vmconfig.vmotionEncryption)"
-        } else {
+        }else{
             Write-ToConsole "...vMotion encryption was incorrectly set to $($vm.extensiondata.Config.MigrateEncryption) on $vm"
             $vmv = $vm | get-view
             $config = new-object VMware.Vim.VirtualMachineConfigSpec
@@ -206,7 +215,7 @@ Try {
             $vmv.ReconfigVM($config)
         }
     }
-} Catch {
+}Catch{
     Write-Error "...Failed to configure virtual machine vMotion encryption"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false
@@ -214,11 +223,11 @@ Try {
 }
 
 ## Set virtual machine logging
-Try {
-    ForEach ($vm in $vms) {
-        If ($vm.ExtensionData.Config.Flags.EnableLogging -eq $vmconfig.vmLogging) {
+Try{
+    ForEach($vm in $vms){
+        If($vm.ExtensionData.Config.Flags.EnableLogging -eq $vmconfig.vmLogging){
             Write-ToConsole "...Logging set correctly on $vm to $($vmconfig.vmLogging)"
-        } else {
+        }else{
             Write-ToConsole "...Logging was incorrectly set to $($vm.ExtensionData.Config.Flags.EnableLogging) on $vm"
             $vmv = $vm | get-view
             $config = new-object VMware.Vim.VirtualMachineConfigSpec
@@ -227,7 +236,7 @@ Try {
             $vmv.ReconfigVM($config)
         }
     }
-} Catch {
+}Catch{
     Write-Error "...Failed to configure virtual machine logging"
     Write-Error $_.Exception
     Disconnect-VIServer -Server $vcenter -Force -Confirm:$false

--- a/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_vCenter_Remediation.ps1
+++ b/vsphere/7.0/vsphere/powercli/VMware_vSphere_7.0_STIG_vCenter_Remediation.ps1
@@ -125,7 +125,7 @@ $VCSA70000079 = $true  #Native Key Provider
 
 
 #Modules needed to run script and load
-$modules = @("VMware.PowerCLI","VMware.Vsphere.SsoAdmin")
+$modules = @("VMware.VimAutomation.Core","VMware.Vsphere.SsoAdmin")
 
 #Check for correct modules
 Function checkModule ($m){


### PR DESCRIPTION
Starting with PowerShell 3.0, modules are loaded automatically. I'm not sure of the target PS version for this module, but if manual module loading is required, the system should load as few modules as possible.

Loading VMware.PowerCLI sometimes takes 30 minutes+ even on a powerful machine. VMware.VimAutomation.Core provides all of the commands that are needed and loads far faster.