### PR TITLE
fix typos and spelling errors

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -60,7 +60,7 @@ A support request may be opened in these cases if a valid support agreement is i
 
 Support for issues related to content in a STIG Readiness Guide should be addressed by emailing: stigs@vmware.com 
 
-Requests recieved will be processed on a best effort basis and any needed content updates published in the next content release. In between releases, issues will be documented in a known issues document available in a products folder in this repository.  
+Requests received will be processed on a best effort basis and any needed content updates published in the next content release. In between releases, issues will be documented in a known issues document available in a products folder in this repository.  
 
 **Product Support**
 

--- a/aria/automation/8.x/inspec/vmware-vra-8x-stig-baseline/README.md
+++ b/aria/automation/8.x/inspec/vmware-vra-8x-stig-baseline/README.md
@@ -24,7 +24,7 @@ InSpec profiles for vRA are available for each component or can be run all or so
 Repository paths:
 * [Photon](https://github.com/vmware/dod-compliance-and-automation/tree/master/photon/3.0/inspec/vmware-photon-3.0-stig-inspec-baseline)
 
-See the [InSpec docs](https://www.inspec.io/docs/reference/profiles/) for more info on profile dependencies and inheritence  
+See the [InSpec docs](https://www.inspec.io/docs/reference/profiles/) for more info on profile dependencies and inheritance  
 
 ## How to run InSpec locally from Powershell on Windows
 

--- a/nsx/3.x/ansible/vmware-nsxt-3.x-stig-ansible-hardening/README.md
+++ b/nsx/3.x/ansible/vmware-nsxt-3.x-stig-ansible-hardening/README.md
@@ -10,7 +10,7 @@ This is a hardening playbook that utilizes Ansible to perform automated remediat
 ## !!Important!!
 - Please read through the README carefully and familiarize yourself with the playbook and ansible before running this playbook
 - As always please ensure you have a backout plan if needed you can roll back the changes
-- This playbook has not been tested for forward or backward compability beyond the version of NSX listed under requirements.
+- This playbook has not been tested for forward or backward compatibility beyond the version of NSX listed under requirements.
 - Some NSX-T STIG controls can be very impactful to your environment if care is not taken during implementation especially in a brownfield scenario. For example, changing the default DFW rule to deny traffic without first creating rules to allow authorized traffic.  
 
 ## Requirements

--- a/nsx/3.x/inspec/vmware-nsxt-3.x-stig-baseline/README.md
+++ b/nsx/3.x/inspec/vmware-nsxt-3.x-stig-baseline/README.md
@@ -46,7 +46,7 @@ Please review the inspec.yml for input variables and specify at runtime or via a
 
 If changes are needed to skip controls or update checks it is recommended to create an overlay profile that has a dependency on this profile with the needed changes so they can be easily tracked 
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 **Note**: Replace the profile's directory name - e.g. - `<Profile>` with `.` if currently in the profile's root directory.  
 

--- a/nsx/4.x/ansible/vmware-nsx-4.x-stig-ansible-hardening/README.md
+++ b/nsx/4.x/ansible/vmware-nsx-4.x-stig-ansible-hardening/README.md
@@ -10,7 +10,7 @@ This is a hardening playbook that utilizes Ansible to perform automated remediat
 ## !!Important!!
 - Please read through the README carefully and familiarize yourself with the playbook and ansible before running this playbook
 - As always please ensure you have a backout plan if needed you can roll back the changes
-- This playbook has not been tested for forward or backward compability beyond the version of NSX listed under requirements.
+- This playbook has not been tested for forward or backward compatibility beyond the version of NSX listed under requirements.
 - Some NSX-T STIG controls can be very impactful to your environment if care is not taken during implementation especially in a brownfield scenario. For example, changing the default DFW rule to deny traffic without first creating rules to allow authorized traffic. 
 
 ## Requirements

--- a/photon/3.0/ansible/vmware-photon-3.0-stig-ansible-hardening/README.md
+++ b/photon/3.0/ansible/vmware-photon-3.0-stig-ansible-hardening/README.md
@@ -51,7 +51,7 @@ ansible-playbook -i 'IP or FQDN', -u 'username' playbook.yml -k -v --tags photon
 ```
 
 ## Misc
-To set syslog or NTP you must update the variables by specifiying them at the command line or by passing a vars file.
+To set syslog or NTP you must update the variables by specifying them at the command line or by passing a vars file.
 
 The DoD SSH banner update is disabled by default. Update the run_sshd_banner_issue variable to enable or disable it.
 

--- a/photon/3.0/inspec/vmware-photon-3.0-stig-inspec-baseline/CHANGELOG.md
+++ b/photon/3.0/inspec/vmware-photon-3.0-stig-inspec-baseline/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 #### Release Notes
 - Updated source SRG to GPOS V2R4
-- PHTN-30-000009, PHTN-30-000064 severity updated to CAT I. Were mistakingly CAT III due to bug in mapping code.
+- PHTN-30-000009, PHTN-30-000064 severity updated to CAT I. Were mistakenly CAT III due to bug in mapping code.
 - PHTN-30-000031 severity updated to CAT II.
 - PHTN-30-000038 test fixed
 - PHTN-30-000041 updated test to work if messages file doesn't exist

--- a/photon/3.0/inspec/vmware-photon-3.0-stig-inspec-baseline/README.md
+++ b/photon/3.0/inspec/vmware-photon-3.0-stig-inspec-baseline/README.md
@@ -47,7 +47,7 @@ Please review the inspec.yml for input variables and specify at runtime or via a
 
 If changes are needed to skip controls or update checks it is recommended to create an overlay profile that has a dependency on this profile with the needed changes so they can be easily tracked 
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 **Note**: Replace the profile's directory name - e.g. - `<Profile>` with `.` if currently in the profile's root directory.  
 

--- a/photon/4.0/ansible/vmware-photon-4.0-stig-ansible-hardening/README.md
+++ b/photon/4.0/ansible/vmware-photon-4.0-stig-ansible-hardening/README.md
@@ -40,7 +40,7 @@ ansible-playbook -i 'IP or FQDN', -u 'username' playbook.yml -k -v --tags photon
 ```
 
 ## Misc
-- To set syslog or NTP you must update the variables by specifiying them at the command line or by passing a vars file.
+- To set syslog or NTP you must update the variables by specifying them at the command line or by passing a vars file.
 - The DoD SSH banner update is disabled by default. Update the run_etc_issue_dod variable to enable or disable it.
 - Steps requiring installs are enabled by default and should be disabled if internet access if not available.
 - Enabling FIPS mode for the kernel is enabled by default. Update the run_fips_boot_enable variable to enable or disable it.

--- a/photon/5.0/ansible/vmware-photon-5.0-stig-ansible-hardening/README.md
+++ b/photon/5.0/ansible/vmware-photon-5.0-stig-ansible-hardening/README.md
@@ -40,7 +40,7 @@ ansible-playbook -i 'IP or FQDN', -u 'username' playbook.yml -k -v --tags photon
 ```
 
 ## Misc
-- To set syslog or NTP you must update the variables by specifiying them at the command line or by passing a vars file.
+- To set syslog or NTP you must update the variables by specifying them at the command line or by passing a vars file.
 - The DoD SSH banner update is disabled by default. Update the run_etc_issue_dod variable to enable or disable it.
 - Steps requiring installs are enabled by default and should be disabled if internet access if not available.
 - Enabling FIPS mode for the kernel is enabled by default. Update the run_fips_boot_enable variable to enable or disable it.

--- a/vcd/10.4/inspec/vmware-cloud-director-10.4-stig-baseline/README.md
+++ b/vcd/10.4/inspec/vmware-cloud-director-10.4-stig-baseline/README.md
@@ -50,7 +50,7 @@ Please review the inspec.yml for input variables and specify at runtime or via a
 
 If changes are needed to skip controls or update checks it is recommended to create an overlay profile that has a dependency on this profile with the needed changes so they can be easily tracked 
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 **Note**: Replace the profile's directory name - e.g. - `<Profile>` with `.` if currently in the profile's root directory.  
 

--- a/vcf/4.x/inspec/vmware-vcf-sddcmgr-4x-stig-baseline/README.md
+++ b/vcf/4.x/inspec/vmware-vcf-sddcmgr-4x-stig-baseline/README.md
@@ -51,7 +51,7 @@ Please review the inspec.yml for input variables and specify at runtime or via a
 
 If changes are needed to skip controls or update checks it is recommended to create an overlay profile that has a dependency on this profile with the needed changes so they can be easily tracked 
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 **Note**: Replace the profile's directory name - e.g. - `<Profile>` with `.` if currently in the profile's root directory.  
 

--- a/vcf/5.x/README.md
+++ b/vcf/5.x/README.md
@@ -12,7 +12,7 @@ The VMware Cloud Foundation 5.x Security Technical Implementation Guides (STIGs)
   - SDDC Manager Appliance
     - Common Services Service
     - Domain Manager Service
-    - Lifecycle Manager Servce
+    - Lifecycle Manager Service
     - NGINX
     - Operations Manager Service
     - Photon OS 3.0

--- a/vcf/5.x/ansible/vmware-cloud-foundation-sddcmgr-5x-stig-ansible-hardening/README.md
+++ b/vcf/5.x/ansible/vmware-cloud-foundation-sddcmgr-5x-stig-ansible-hardening/README.md
@@ -10,7 +10,7 @@ This is a hardening playbook that utilizes Ansible to perform automated remediat
 - Please read through the README carefully and familiarize yourself with the playbook and ansible before running this playbook
 - As always please ensure you have a backout plan if needed you can roll back the changes
 - In order to run the Photon role it must be installed as a role so that this playbook may find it
-- This playbook has not been tested for forward or backward compability beyond the version of SDDC Manager listed under requirements.
+- This playbook has not been tested for forward or backward compatibility beyond the version of SDDC Manager listed under requirements.
 
 ## Requirements
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html) installed on a machine that can SSH to the target node(s).  Tested with Ansible 2.12.8.

--- a/vcf/5.x/inspec/vmware-cloud-foundation-sddcmgr-5x-stig-baseline/README.md
+++ b/vcf/5.x/inspec/vmware-cloud-foundation-sddcmgr-5x-stig-baseline/README.md
@@ -6,7 +6,7 @@ STIG Type: STIG Readiness Guide
 ## SDDC Manager InSpec Profiles
 InSpec profiles for the SDDC Manager are available for each component or can be run all or some from the wrapper/overlay profile. Note the wrapper profile is setup to reference the other profiles from the same relative folder structure as seen here.  
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 
 ## Requirements

--- a/vsphere/6.7/vcsa/ansible/vmware-vcsa-6.7-stig-ansible-hardening/README.md
+++ b/vsphere/6.7/vcsa/ansible/vmware-vcsa-6.7-stig-ansible-hardening/README.md
@@ -61,7 +61,7 @@ ansible-playbook -i 'IP or FQDN', -u 'username' vcsa-stig.yaml -k -v --tags phot
 
 
 ## Misc
-To set syslog or NTP you must update the variables at the top of /roles/photon/vars/main.yml or specifiy then at the command line
+To set syslog or NTP you must update the variables at the top of /roles/photon/vars/main.yml or specify then at the command line
 
 Disabling root ssh logins is set to false in the default variables yaml for Photon. You should configure other ssh access besides root before enabling this control if needed.  
 

--- a/vsphere/6.7/vcsa/inspec/vmware-vcsa-6.7-stig-baseline/README.md
+++ b/vsphere/6.7/vcsa/inspec/vmware-vcsa-6.7-stig-baseline/README.md
@@ -6,7 +6,7 @@ Version: 6.7.0 Version 1 Release 2
 
 InSpec profiles for the VCSA are available for each component or can be run all or some from the wrapper/overlay profile. Note the profile is setup to reference the other profiles from the same relative folder structure as seen here.  
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 
 ## How to run InSpec locally from Powershell on Windows

--- a/vsphere/7.0/README.md
+++ b/vsphere/7.0/README.md
@@ -16,7 +16,7 @@ The VMware vSphere 7.0 Security Technical Implementation Guides (STIGs) provide 
   - vCenter Server Appliance
     - EAM Service
     - Lookup Service
-    - Perfcharts Servce
+    - Perfcharts Service
     - PostgreSQL
     - Reverse Proxy
     - STS Service

--- a/vsphere/7.0/docs/known-issues.md
+++ b/vsphere/7.0/docs/known-issues.md
@@ -64,7 +64,7 @@ In the check and fix only the Administrator role is listed as having cryptograph
 
 Related issue: [#122](https://github.com/vmware/dod-compliance-and-automation/issues/122)
 
-In the check exmaple output "Audit Remote Host Enabled" should read "Audit Record Remote Transmission Active". The fix steps are correct as is.
+In the check example output "Audit Remote Host Enabled" should read "Audit Record Remote Transmission Active". The fix steps are correct as is.
 
 **Workaround:**
 
@@ -150,7 +150,7 @@ Starting in vCenter 7.0 U3L there is a 3rd entry for `url.access-deny` displayed
 
 **Workaround:**
 
-- Remove any duplicate `url.access-deny` entires added to `/opt/vmware/etc/lighttpd/lighttpd.conf`.  
+- Remove any duplicate `url.access-deny` entries added to `/opt/vmware/etc/lighttpd/lighttpd.conf`.  
 - Use the new check and fix text below for this control.  
 ```
 ## New Check

--- a/vsphere/7.0/vcsa/inspec/vmware-vcsa-7.0-stig-baseline/README.md
+++ b/vsphere/7.0/vcsa/inspec/vmware-vcsa-7.0-stig-baseline/README.md
@@ -7,7 +7,7 @@ STIG Type: Official STIG
 
 InSpec profiles for the VCSA are available for each component or can be run all or some from the wrapper/overlay profile. Note the wrapper profile is setup to reference the other profiles from the same relative folder structure as seen here.  
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 
 ## How to run InSpec locally from Powershell on Windows

--- a/vsphere/7.0/vsphere/inspec/vmware-vsphere-7.0-stig-baseline/README.md
+++ b/vsphere/7.0/vsphere/inspec/vmware-vsphere-7.0-stig-baseline/README.md
@@ -21,7 +21,7 @@ This is a compliance auditing profile that is based on Chef InSpec/CINC Auditor 
 
 InSpec profiles for vSphere are available for each component or can be run all or some from the overlay profile. Note the overlay profile is setup to reference the other profiles from the same relative folder structure as seen here.  
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 
 ## How to run InSpec locally from Powershell on Windows

--- a/vsphere/8.0/README.md
+++ b/vsphere/8.0/README.md
@@ -17,7 +17,7 @@ The VMware vSphere 8 Security Technical Implementation Guides (STIGs) provide se
     - EAM Service
     - Envoy
     - Lookup Service
-    - Perfcharts Servce
+    - Perfcharts Service
     - Photon OS
     - PostgreSQL
     - STS Service

--- a/vsphere/8.0/vcsa/ansible/vmware-vcsa-8.0-stig-ansible-hardening/README.md
+++ b/vsphere/8.0/vcsa/ansible/vmware-vcsa-8.0-stig-ansible-hardening/README.md
@@ -11,7 +11,7 @@ This is a hardening playbook that utilizes Ansible to perform automated remediat
 - As always please ensure you have a backout plan if needed you can roll back the changes
 - This playbook does not cover the vSphere (ESXi,VM,vCenter) which are in a companion PowerCLI script
 - In order to run the Photon role it must be installed as a role so that this playbook may find it
-- This playbook has not been tested for forward or backward compability beyond the version of vCenter listed under requirements.
+- This playbook has not been tested for forward or backward compatibility beyond the version of vCenter listed under requirements.
 
 ## Requirements
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/index.html) installed on a machine that can SSH to the target node(s).  Tested with Ansible 2.12.8.

--- a/vsphere/8.0/vcsa/inspec/vmware-vcsa-8.0-stig-baseline/README.md
+++ b/vsphere/8.0/vcsa/inspec/vmware-vcsa-8.0-stig-baseline/README.md
@@ -7,7 +7,7 @@ STIG Type: STIG Readiness Guide
 
 InSpec profiles for the VCSA are available for each component or can be run all or some from the wrapper/overlay profile. Note the wrapper profile is setup to reference the other profiles from the same relative folder structure as seen here.  
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 
 ## How to run InSpec locally from Powershell on Windows

--- a/vsphere/8.0/vsphere/inspec/vmware-vsphere-8.0-stig-baseline/README.md
+++ b/vsphere/8.0/vsphere/inspec/vmware-vsphere-8.0-stig-baseline/README.md
@@ -22,7 +22,7 @@ This is a compliance auditing profile that is based on Chef InSpec/CINC Auditor 
 
 InSpec profiles for vSphere are available for each component or can be run all or some from the overlay profile. Note the overlay profile is setup to reference the other profiles from the same relative folder structure as seen here.  
 
-[See the InSpec docs for more info on Profile dependencies and inheritence](https://www.inspec.io/docs/reference/profiles/)
+[See the InSpec docs for more info on Profile dependencies and inheritance](https://www.inspec.io/docs/reference/profiles/)
 
 
 ## How to run InSpec locally from Powershell on Windows


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.