### PR TITLE
Creating /var/lib/rpm folder for audit parsing

### DIFF
--- a/photon/5.0/ansible/vmware-photon-5.0-stig-ansible-hardening/tasks/photon.yml
+++ b/photon/5.0/ansible/vmware-photon-5.0-stig-ansible-hardening/tasks/photon.yml
@@ -142,6 +142,14 @@
   tags: [PHTN-50-000003, PHTN-50-000019, PHTN-50-000031, PHTN-50-000076, PHTN-50-000078, PHTN-50-000107, PHTN-50-000173, PHTN-50-000175, PHTN-50-000204, PHTN-50-000238, auditd]
   when: run_auditd_rules | bool
   block:
+    - name: PHTN-50-000003 - Create /var/lib/rpm folder if exists
+      ansible.builtin.file:
+        path: /var/lib/rpm
+        state: directory
+        mode: "0750"
+        owner: root
+        group: root
+
     - name: PHTN-50-000003 - Check to see if auditd is installed
       ansible.builtin.shell: |
         set -o pipefail


### PR DESCRIPTION
Default Photon 5 installation does not have the `/var/lib/rpm` folder by default, breaking the audit.STIG.rules file trying to parse it. Creating the directory before calling the handler.

```
vsphere-iso.vsphere: fatal: [default]: FAILED! => {"changed": false, "cmd": ["/sbin/augenrules", "--load"], "delta": "0:00:00.029387", "end": "2023-09-27 00:56:21.228947", "msg": "non-zero return code", "rc": 1, "start": "2023-09-27 00:56:21.199560", "stderr": "Error sending add rule data request (No such file or directory)\nThere was an error in line 43 of /etc/audit/audit.rules", "stderr_lines": ["Error sending add rule data request (No such file or directory)", "There was an error in line 43 of /etc/audit/audit.rules"], "stdout": "No rules\nenabled 1\nfailure 1\npid 6743\nrate_limit 0\nbacklog_limit 640\nlost 0\nbacklog 4\nbacklog_wait_time 15000\nbacklog_wait_time_actual 0", "stdout_lines": ["No rules", "enabled 1", "failure 1", "pid 6743", "rate_limit 0", "backlog_limit 640", "lost 0", "backlog 4", "backlog_wait_time 15000", "backlog_wait_time_actual 0"]}
```