### PR TITLE
Updated Control 000067 xPath code

### DIFF
--- a/aria/operations/8.x/v1r2-srg/inspec/vmware-aria-operations-8x-stig-baseline/api/controls/VRPI-8X-000067.rb
+++ b/aria/operations/8.x/v1r2-srg/inspec/vmware-aria-operations-8x-stig-baseline/api/controls/VRPI-8X-000067.rb
@@ -47,6 +47,6 @@ control 'VRPI-8X-000067' do
 
   # Find Host elements with missing ErrorReportValue, or if present, the showServerInfo is not set to false
   describe xmlconf do
-    its(["name(//Host[not(Valve[contains(@className, 'ErrorReportValve')])] | //Host[Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo != 'false'])"]) { should cmp [] }
+    its(["//Host/Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo"]) { should cmp ['false'] }
   end
 end

--- a/aria/operations/8.x/v1r2-srg/inspec/vmware-aria-operations-8x-stig-baseline/casa/controls/VRPS-8X-000067.rb
+++ b/aria/operations/8.x/v1r2-srg/inspec/vmware-aria-operations-8x-stig-baseline/casa/controls/VRPS-8X-000067.rb
@@ -47,6 +47,6 @@ control 'VRPS-8X-000067' do
 
   # Find Host elements with missing ErrorReportValue, or if present, the showServerInfo is not set to false
   describe xmlconf do
-    its(["name(//Host[not(Valve[contains(@className, 'ErrorReportValve')])] | //Host[Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo != 'false'])"]) { should cmp [] }
+    its(["//Host/Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo"]) { should cmp ['false'] }
   end
 end

--- a/aria/operations/8.x/v1r2-srg/inspec/vmware-aria-operations-8x-stig-baseline/ui/controls/VRPU-8X-000067.rb
+++ b/aria/operations/8.x/v1r2-srg/inspec/vmware-aria-operations-8x-stig-baseline/ui/controls/VRPU-8X-000067.rb
@@ -47,6 +47,6 @@ control 'VRPU-8X-000067' do
 
   # Find Host elements with missing ErrorReportValue, or if present, the showServerInfo is not set to false
   describe xmlconf do
-    its(["name(//Host[not(Valve[contains(@className, 'ErrorReportValve')])] | //Host[Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo != 'false'])"]) { should cmp [] }
+    its(["//Host/Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo"]) { should cmp ['false'] }
   end
 end


### PR DESCRIPTION
was throwing an error when ran

Tested on Aria 8.16 with Inspec 4.18
tests included:

1. commenting out ErrorReportValve
2. changing showServerInfo to true
3. removing showServerInfo

known/potential issues:
report valve will still match so long as ErrorReportValve, shouldn't be an issue unless typos happen.
doesn't scan for every host value, assumed it wasn't needed for this could be fixed with a count or something similar:

`its(["count(//Host[not(Valve[contains(@className, 'ErrorReportValve')])]) | //Host[Valve[contains(@className, 'ErrorReportValve')]/@showServerInfo != 'false'])"]) { should cmp [0] }`

