### PR TITLE
Add vccred parameters to vSphere InSpec runner scripts

### DIFF
--- a/vsphere/7.0/v1r3-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_InSpec_Runner.ps1
+++ b/vsphere/7.0/v1r3-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_InSpec_Runner.ps1
@@ -12,7 +12,7 @@
 .NOTES 
   File Name  : VMware_vSphere_7.0_STIG_ESXi_InSpec_Runner.ps1 
   Author     : Ryan Lakey
-  Version    : 1.0
+  Version    : 1.1
 
   Tested against
   -PowerCLI 13
@@ -26,6 +26,8 @@
 
 .PARAMETER vcenter
   Enter the vcenter to connect to and collect hosts to audit.
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
 .PARAMETER reportPath
   Enter the folder path to store reports, for example: C:\InSpec\Reports.
 .PARAMETER inspecPath
@@ -42,6 +44,8 @@ param (
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
   [Parameter(Mandatory=$true,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
   [string]$reportPath = "C:\InSpec\Reports",
@@ -95,9 +99,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/7.0/v1r3-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_InSpec_Runner.ps1
+++ b/vsphere/7.0/v1r3-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_7.0_STIG_VM_InSpec_Runner.ps1 
   Author     : Ryan Lakey
-  Version    : 1.0
+  Version    : 1.1
 
   Tested against
   -PowerCLI 13
@@ -25,6 +25,8 @@
 
 .PARAMETER vcenter
   Enter the vcenter to connect to and collect hosts to audit.
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
 .PARAMETER reportPath
   Enter the folder path to store reports, for example: C:\InSpec\Reports.
 .PARAMETER inspecPath
@@ -38,6 +40,8 @@ param (
   HelpMessage="Enter the vCenter FQDN or IP to connect to")]
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
@@ -88,9 +92,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/7.0/v1r4-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_InSpec_Runner.ps1
+++ b/vsphere/7.0/v1r4-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_ESXi_InSpec_Runner.ps1
@@ -12,7 +12,7 @@
 .NOTES 
   File Name  : VMware_vSphere_7.0_STIG_ESXi_InSpec_Runner.ps1 
   Author     : Ryan Lakey
-  Version    : 1.0
+  Version    : 1.1
 
   Tested against
   -PowerCLI 13
@@ -26,6 +26,8 @@
 
 .PARAMETER vcenter
   Enter the vcenter to connect to and collect hosts to audit.
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
 .PARAMETER reportPath
   Enter the folder path to store reports, for example: C:\InSpec\Reports.
 .PARAMETER inspecPath
@@ -42,6 +44,8 @@ param (
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
   [Parameter(Mandatory=$true,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
   [string]$reportPath = "C:\InSpec\Reports",
@@ -95,9 +99,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/7.0/v1r4-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_InSpec_Runner.ps1
+++ b/vsphere/7.0/v1r4-stig/vsphere/powercli/VMware_vSphere_7.0_STIG_VM_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_7.0_STIG_VM_InSpec_Runner.ps1 
   Author     : Ryan Lakey
-  Version    : 1.0
+  Version    : 1.1
 
   Tested against
   -PowerCLI 13
@@ -25,6 +25,8 @@
 
 .PARAMETER vcenter
   Enter the vcenter to connect to and collect hosts to audit.
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
 .PARAMETER reportPath
   Enter the folder path to store reports, for example: C:\InSpec\Reports.
 .PARAMETER inspecPath
@@ -38,6 +40,8 @@ param (
   HelpMessage="Enter the vCenter FQDN or IP to connect to")]
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
@@ -88,9 +92,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/8.0/v2r1-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1
+++ b/vsphere/8.0/v2r1-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1 
   Author     : Broadcom
-  Version    : 2.0.1
+  Version    : 2.0.3
 
   Minimum Requirements
   -PowerCLI 13.3
@@ -33,7 +33,9 @@
   Enter the path for the InSpec inputs file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-inputs-example.yml
 .PARAMETER attestationFile
   Enter the path for the saf cli attestation file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-attestation-example.yml
-#>
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
+  #>
 [CmdletBinding()]
 param (
   [Parameter(Mandatory=$true,
@@ -41,6 +43,8 @@ param (
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
   [Parameter(Mandatory=$true,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
   [string]$reportPath = "C:\InSpec\Reports",
@@ -94,9 +98,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/8.0/v2r1-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1
+++ b/vsphere/8.0/v2r1-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1 
   Author     : VMware
-  Version    : 2.0.1
+  Version    : 2.0.2
 
   Minimum Requirements
   -PowerCLI 13.3
@@ -31,13 +31,17 @@
   Enter the folder path for the InSpec Profile for the vSphere VM 8.0 baseline...!!CANNOT HAVE SPACES!!
 .PARAMETER attestationFile
   Enter the path for the saf cli attestation file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-attestation-example.yml
-#>
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
+  #>
 [CmdletBinding()]
 param (
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the vCenter FQDN or IP to connect to")]
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
@@ -88,9 +92,12 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
+
 
 #Connect to vCenter Server
 Try

--- a/vsphere/8.0/v2r2-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1
+++ b/vsphere/8.0/v2r2-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1 
   Author     : Broadcom
-  Version    : 2.0.2
+  Version    : 2.0.3
 
   Minimum Requirements
   -PowerCLI 13.3
@@ -33,7 +33,9 @@
   Enter the path for the InSpec inputs file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-inputs-example.yml
 .PARAMETER attestationFile
   Enter the path for the saf cli attestation file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-attestation-example.yml
-#>
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
+  #>
 [CmdletBinding()]
 param (
   [Parameter(Mandatory=$true,
@@ -41,6 +43,8 @@ param (
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
   [Parameter(Mandatory=$true,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
   [string]$reportPath = "C:\InSpec\Reports",
@@ -94,9 +98,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/8.0/v2r2-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1
+++ b/vsphere/8.0/v2r2-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1 
   Author     : VMware
-  Version    : 2.0.1
+  Version    : 2.0.2
 
   Minimum Requirements
   -PowerCLI 13.3
@@ -31,13 +31,17 @@
   Enter the folder path for the InSpec Profile for the vSphere VM 8.0 baseline...!!CANNOT HAVE SPACES!!
 .PARAMETER attestationFile
   Enter the path for the saf cli attestation file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-attestation-example.yml
-#>
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
+  #>
 [CmdletBinding()]
 param (
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the vCenter FQDN or IP to connect to")]
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
@@ -88,9 +92,12 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
+
 
 #Connect to vCenter Server
 Try

--- a/vsphere/8.0/v2r3-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1
+++ b/vsphere/8.0/v2r3-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_8.0_STIG_ESXi_InSpec_Runner.ps1 
   Author     : Broadcom
-  Version    : 2.0.2
+  Version    : 2.0.3
 
   Minimum Requirements
   -PowerCLI 13.3
@@ -33,7 +33,9 @@
   Enter the path for the InSpec inputs file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-inputs-example.yml
 .PARAMETER attestationFile
   Enter the path for the saf cli attestation file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-attestation-example.yml
-#>
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
+  #>
 [CmdletBinding()]
 param (
   [Parameter(Mandatory=$true,
@@ -41,6 +43,8 @@ param (
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
   [Parameter(Mandatory=$true,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
   [string]$reportPath = "C:\InSpec\Reports",
@@ -94,9 +98,11 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
 
 #Connect to vCenter Server
 Try

--- a/vsphere/8.0/v2r3-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1
+++ b/vsphere/8.0/v2r3-stig/vsphere/powercli/VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1
@@ -11,7 +11,7 @@
 .NOTES 
   File Name  : VMware_vSphere_8.0_STIG_VM_InSpec_Runner.ps1 
   Author     : VMware
-  Version    : 2.0.1
+  Version    : 2.0.2
 
   Minimum Requirements
   -PowerCLI 13.3
@@ -31,13 +31,17 @@
   Enter the folder path for the InSpec Profile for the vSphere VM 8.0 baseline...!!CANNOT HAVE SPACES!!
 .PARAMETER attestationFile
   Enter the path for the saf cli attestation file, for example: C:\github\dod-compliance-and-automation\vsphere\8.0\vsphere\powercli\vmware-vsphere-8.0-stig-esxi-inspec-runner-attestation-example.yml
-#>
+.PARAMETER vccred
+  Passthrough the PSScredential object for vSphere credentials
+  #>
 [CmdletBinding()]
 param (
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the vCenter FQDN or IP to connect to")]
   [ValidateNotNullOrEmpty()]
   [string]$vcenter,
+  [Parameter(Mandatory=$false)]
+  [pscredential]$vccred,
   [Parameter(Mandatory=$true,
   HelpMessage="Enter the folder path to store reports for example...C:\InSpec\Reports")]
   [ValidateNotNullOrEmpty()]
@@ -88,9 +92,12 @@ Catch
   Exit -1
 }
 
-#Get Credentials for vCenter
-Write-ToConsole "...Enter credentials to connect to vCenter"
-$vccred = Get-Credential -Message "Enter credentials for vCenter"
+#Get Credentials for vCenter if not specified during initial run
+if ($null -eq $vccred) {
+  Write-ToConsole "...Enter credentials to connect to vCenter"
+  $vccred = Get-Credential -Message "Enter credentials for vCenter"
+}
+
 
 #Connect to vCenter Server
 Try


### PR DESCRIPTION
The changes add the vccred parameter to the vSphere InSpec runner scripts, so these scripts can be executed from other scripts, and utilize already created credential objects.